### PR TITLE
REFACTOR: make the scripts and the doc clearer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { version = "0.74.1", path = "../../nushell/nushell/crates/nu-plugin" }
-nu-protocol = { version = "0.74.1", path = "../../nushell/nushell/crates/nu-protocol", features = ["plugin"] }

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ An example plugin for `nushell` to compute length of `String`s
 to correctly install these dependencies, which btw are not present at all in the `Cargo.toml`
 to avoid any issues, one can (and probably should) run the following
 ```bash
-> git clone https://github.com/nushell/nushell <path-to-nushell>
+> git clone https://github.com/nushell/nushell /path/to/nushell/
 ```
 or choose another way to get the source code of `nushell` somewhere locally :yum:
 
 then
 ```
 > use toolkit.nu
-> toolkit setup <path-to-nushell>
+> toolkit setup /path/to/nushell/
 ```
 
 and *voila*
@@ -33,11 +33,11 @@ cargo install --path .
 ```
 - register the plugin in `nushell` with
 ```bash
-register ~/.local/share/cargo/bin/nu_plugin_len
+register /path/to/cargo/bin/nu_plugin_len
 ```
 
 > **Note**  
-> i use `~/.local/share/cargo/bin/nu_plugin_len` in the `register`
+> for instance, i use `~/.local/share/cargo/bin/nu_plugin_len` in the `register`
 > above because my `CARGO_HOME` is set to `($env.XDG_DATA_HOME | path join "cargo")`,
 > i.e. `~/.local/share/cargo`, in my `env.nu`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # nu_plugin_len
 An example plugin for `nushell` to compute length of `String`s
 
+## :package: change the path to the dependencies
+> **Warning**  
+> because all the dependencies for this plugin are not on *crates.io*, but rather
+> only in the source of `nushell`, the path to all these dependencies,
+> i.e. `nu-plugin` and `nu-protocol` are hardcoded to the `nushell` source on my machine.
+>
+> even though the paths do not mention `amtoine`, they still are unique to my system...
+
+i've added a little script in [`scripts/`](scripts) called [`add-deps.nu`](scripts/add-deps.nu):
+- have a look at `./scripts/add-deps.nu --help` for more information about the script
+to correctly install these dependencies, which btw are not present at all in the `Cargo.toml`
+to avoid any issues, one can (and probably should) run the following
+```bash
+> git clone https://github.com/nushell/nushell <path-to-nushell>
+```
+or choose another way to get the source code of `nushell` somewhere locally :yum:
+then
+```
+> use toolkit.nu
+> toolkit setup <path-to-nushell>
+```
+
+and *voila*
+> **Note**  
+> check `git diff Cargo.toml` to see the change :wink:
+
 ## :open_file_folder: install the plugin
 - build and install the binary with
 ```bash
@@ -22,16 +48,11 @@ register ~/.local/share/cargo/bin/nu_plugin_len
 25
 ```
 
-## :package: change the path to the dependencies
-> **Warning**  
-> the path to the dependencies, i.e. `nu-plugin` and `nu-protocol` are hardcoded to
-> the `nushell` source on my machine.
-> even though the paths do not mention `amtoine`, they still are unique to my system...
-
-i've added a little script in [`scripts/`](scripts) called [`add-deps.nu`](scripts/add-deps.nu):
-- have a look at `./scripts/add-deps.nu --help` for more information about the script
-
 ## :scroll: documentation
 one can have a look at the documentation of the crate by going to [`docs/`](docs)
 > **Note**  
-> this documentation has bee generated with `./scripts/doc.nu`
+> this documentation has been generated with
+> ```bash
+> > use toolkit.nu
+> > toolkit doc
+> ```

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ An example plugin for `nushell` to compute length of `String`s
 >
 > even though the paths do not mention `amtoine`, they still are unique to my system...
 
-i've added a little script in [`scripts/`](scripts) called [`add-deps.nu`](scripts/add-deps.nu):
-- have a look at `./scripts/add-deps.nu --help` for more information about the script
 to correctly install these dependencies, which btw are not present at all in the `Cargo.toml`
 to avoid any issues, one can (and probably should) run the following
 ```bash
 > git clone https://github.com/nushell/nushell <path-to-nushell>
 ```
 or choose another way to get the source code of `nushell` somewhere locally :yum:
+
 then
 ```
 > use toolkit.nu

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ This `nu_plugin_len` is greatly inspired by
 ### some invalid non-string values
 ```bash
 > 1 | len
-Error: 
+Error:
   × Input is not a string: found int
    ╭─[entry #4:1:1]
  1 │ 1 | len
@@ -29,7 +29,7 @@ Error:
    ╰────
 
 > true | len
-Error: 
+Error:
   × Input is not a string: found bool
    ╭─[entry #5:1:1]
  1 │ true | len
@@ -38,7 +38,7 @@ Error:
    ╰────
 
 > 1.23 | len
-Error: 
+Error:
   × Input is not a string: found float
    ╭─[entry #7:1:1]
  1 │ 1.23 | len
@@ -47,7 +47,7 @@ Error:
    ╰────
 
 > {a: "Happy", b: "new", c: "year"} | len
-Error: 
+Error:
   × Input is not a string: found record<a: string, b: string, c: string>
    ╭─[entry #8:1:1]
  1 │ {a: "Happy", b: "new", c: "year"} | len

--- a/scripts/doc.nu
+++ b/scripts/doc.nu
@@ -1,9 +1,0 @@
-#!/usr/bin/env nu
-
-open src/main.rs
-| lines
-| parse "//!{line}"
-| get line
-| str replace " " ""
-| str join "\n"
-| save --force docs/README.md

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -1,18 +1,17 @@
-#!/usr/bin/env nu
-
 # add the dependencies of `nu_plugin_len` to the `Cargo.toml` file
 #
-# Example:
+# # Example:
 # as i store all my git-related projects under `$env.GIT_REPOS_HOME`, inside a directory
 # with format "{host}/{owner}/{repository}":
 #
 # ```bash
-# ./scripts/add-deps.nu (
+# > use toolkit.nu
+# > toolkit setup (
 #     $env.GIT_REPOS_HOME | path join "github.com" "nushell" "nushell"
 # )
 # ```
 #
-# might result in a diff in the repo similar to 
+# might result in a diff in the repo similar to
 #
 # ```diff
 # diff --git a/Cargo.toml b/Cargo.toml
@@ -21,14 +20,14 @@
 # +++ b/Cargo.toml
 # @@ -6,5 +6,5 @@ edition = "2021"
 #  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-#  
+#
 #  [dependencies]
 # -nu-plugin = { version = "0.74.1", path = "../../nushell/nushell/crates/nu-plugin" }
 # -nu-protocol = { version = "0.74.1", path = "../../nushell/nushell/crates/nu-protocol", features = ["plugin"] }
 # +nu-plugin = { version = "<version>", path = "/path/to/nushell/crates/nu-plugin" }
 # +nu-protocol = { version = "<version>", path = "/path/to/nushell/crates/nu-protocol", features = ["plugin"] }
 # ```
-def main [
+export def setup [
     nushell_path: string  # the path to the root of the nushell source
 ] {
     let crates_path = ($nushell_path | path join "crates")
@@ -36,3 +35,12 @@ def main [
     cargo add nu-protocol --path ($crates_path | path join "nu-protocol") --features plugin
 }
 
+export def doc [] {
+    open src/main.rs
+    | lines
+    | parse "//!{line}"
+    | get line
+    | str replace " " ""
+    | str join "\n"
+    | save --force docs/README.md
+}


### PR DESCRIPTION
Should close #1.

> **Note**
> see the [`README`](https://github.com/amtoine/nu_plugin_len/tree/refactor/make-the-scripts-and-the-doc-clearer)

this PR
- refactor the old `scripts/*.nu` inside a single `toolkit.nu` module
- the instructions have been made clearer in the `README.md`
- the `docs/` have been regenerated
- the hardcoded dependencies have been removed from the `Cargo.toml`, thus requiring the use of `toolkit setup`